### PR TITLE
Fixed redirect referer original url is lost after successful login

### DIFF
--- a/Component/Authentication/Handler/LoginSuccessHandler.php
+++ b/Component/Authentication/Handler/LoginSuccessHandler.php
@@ -39,7 +39,8 @@ class LoginSuccessHandler extends BaseLoginSuccessHandler
                     if(stristr($session->get('referer'), '/js/routing')) {
                         $response = new RedirectResponse($this->getRedirectUrl($request));
                     } else {
-                        $response = new RedirectResponse($this->getRedirectUrl($request, $session->get('referer')));
+                        //$response = new RedirectResponse($this->getRedirectUrl($request, $session->get('referer')));
+                        $response = new RedirectResponse($session->get('referer'));
                     }
                 } else {
                     $response = new RedirectResponse($this->getRedirectUrl($request));

--- a/Component/Authentication/Handler/LogoutSuccessHandler.php
+++ b/Component/Authentication/Handler/LogoutSuccessHandler.php
@@ -33,7 +33,7 @@ class LogoutSuccessHandler extends BaseLogoutSuccessHandler
                     if(stristr($session->get('referer'), '/js/routing')) {
                         $response = new RedirectResponse($this->getRedirectUrl($request));
                     } else {
-                        $response = new RedirectResponse($this->getRedirectUrl($request, $session->get('referer')));
+                        $response = new RedirectResponse($session->get('referer'));
                     }
                 } else {
 

--- a/Component/Listener/RouteRefererListener.php
+++ b/Component/Listener/RouteRefererListener.php
@@ -8,5 +8,27 @@ use CCDNUser\SecurityBundle\Component\Listener\RouteRefererListener as BaseRoute
 
 class RouteRefererListener extends BaseRouteRefererListener
 {
+    public function onKernelRequest(GetResponseEvent $event)
+    {
+        // Abort if we are dealing with some symfony2 internal requests.
+        if ($event->getRequestType() !== \Symfony\Component\HttpKernel\HttpKernel::MASTER_REQUEST) {
+            return;
+        }
 
+        // Get the route from the request object.
+        $request = $event->getRequest();
+        $route = $request->get('_route');
+
+        if (in_array($route, $this->routeIgnoreList)) {
+            return;
+        }
+
+        // Check for any internal routes.
+        if ($route[0] == '_') {
+            return;
+        }
+        // Get the session and assign it the url we are at presently.
+        $session = $request->getSession();
+        $session->set('referer', $request->getRequestUri());
+    }
 }


### PR DESCRIPTION
Override referer: instead of using the $request->getPathInfo() that returns only the route path, replaced with $request->getRequestUri() to return all path including the query string parameters of the current request uri
