### PR TITLE
Update OverrideServiceCompilerPass.php

### DIFF
--- a/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
+++ b/DependencyInjection/Compiler/OverrideServiceCompilerPass.php
@@ -13,8 +13,8 @@ class OverrideServiceCompilerPass implements CompilerPassInterface
 //        $definition = $container->getDefinition('ccdn_user_security.component.listener.blocking_login_listener');
 //        $definition->setClass($container->getParameter('rz_user_security.component.listener.blocking_login_listener.class'));
 //
-//        $definition = $container->getDefinition('ccdn_user_security.component.listener.route_referer_listener');
-//        $definition->setClass($container->getParameter('rz_user_security.component.listener.route_referer_listener.class'));
+        $definition = $container->getDefinition('ccdn_user_security.component.listener.route_referer_listener');
+        $definition->setClass($container->getParameter('rz_user_security.component.listener.route_referer_listener.class'));
 
         $definition = $container->getDefinition('ccdn_user_security.component.authentication.handler.login_failure_handler');
         $definition->setClass($container->getParameter('rz_user_security.component.authentication.handler.login_failure_handler.class'));


### PR DESCRIPTION
Enabled the overridden route referrer listener to fix the issue with missing query string parameters
